### PR TITLE
Separate loading configuration and packages

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -21,28 +21,6 @@ local fey_load_packages = vim.g.fey_load_packages == true or (type(vim.g.fey_loa
 -- if g:fey_load_config == true or not 0, assume true if nil
 local fey_load_config = vim.g.fey_load_config == nil or vim.g.fey_load_config == true or (type(vim.g.fey_load_config) == 'number' and vim.g.fey_load_config ~= 0)
 
--- setup minpac
-if fey_load_packages then
-	-- put minpac into rtp
-	vim.cmd'packadd minpac'
-
-	-- wrapper for minpac
-	minpac = {
-		init = vim.fn['minpac#init'],
-		add = vim.fn['minpac#add'],
-		update = vim.fn['minpac#update'],
-		clean = vim.fn['minpac#clean'],
-		getplugininfo = vim.fn['minpac#getplugininfo'],
-		getpluginlist = vim.fn['minpac#getpluginlist'],
-		getpackages = vim.fn['minpac#getpackages'],
-		status = vim.fn['minpac#status'],
-	}
-
-	-- load minpac
-	minpac.init{ confirm = false }
-	minpac.add('k-takata/minpac', {type = 'opt'})
-end
-
 -- dofile, but does nothing if the file doesn't exists, and prints a friendly
 -- error (without crashing) if the file throws and error
 local function load_file_lenient(file)
@@ -65,11 +43,6 @@ fey.load_module = function(module_d, name, features)
 	if fey[name] == nil then fey[name] = {} end
 	fey[name].features = features
 
-	if fey_load_packages then
-		-- load packages.lua
-		load_file_lenient(module_d .. '/packages.lua')
-	end
-	if fey_load_config then
 		-- load config.lua, with an augroup setup for the file's own
 		-- use and for us to put an autoreload autocmd
 		local config_f = module_d .. '/config.lua'
@@ -82,49 +55,101 @@ fey.load_module = function(module_d, name, features)
 		load_file_lenient(config_f)
 
 		vim.cmd('augroup END')
-	end
 end
 
-
--- loads ~/.config/nvim, or wherever FEY is installed. Runs the /packages.lua
--- and /config.lua
-fey.load_module(fey_core_d, 'core')
-
--- loads ~/.config/fey, or similar. Runs the user's /packages.lua
--- and the user's /config.lua
+-- root path of init.lua to config/fey or ./skel
 fey_user_d = config_d .. '/fey'
 if vim.fn.isdirectory(fey_user_d) == 0 then
 	fey_user_d = fey_core_d .. '/skel'
 end
-fey.load_module(fey_user_d, 'user')
 
 -- the user's init.lua contains a list of modules to activate
 local init_f = fey_user_d .. '/init.lua'
 local core_module_d = fey_core_d .. '/modules'
 local user_modules_d = fey_user_d .. '/modules'
 
--- /modules is split into categories
-for category, modules in pairs(dofile(init_f)) do
-	-- that contain modules
-	for key, value in pairs(modules) do
-		-- sometimes the module's name is a string in list, sometimes
-		-- an index value
-		local module = type(key) == 'string' and key or value
-		-- sometimes the modules have sub-features, if the key is a
-		-- number, set the value as the key (for convenience)
-		local features = type(value) == 'table' and value or {}
-		for key, value in pairs(features) do
-			if type(key) == 'number' then
-				features[value] = key
-			end
-		end
+fey.load_packages = function() -- NOTE: callable I think, maybe replace sync?
+-- setup minpac
+	-- put minpac into rtp
+	vim.cmd'packadd minpac'
 
-		-- load up the module from ~/.config/fey/modules if possible,
+	-- wrapper for minpac
+	minpac = {
+		init = vim.fn['minpac#init'],
+		add = vim.fn['minpac#add'],
+		update = vim.fn['minpac#update'],
+		clean = vim.fn['minpac#clean'],
+		getplugininfo = vim.fn['minpac#getplugininfo'],
+		getpluginlist = vim.fn['minpac#getpluginlist'],
+		getpackages = vim.fn['minpac#getpackages'],
+		status = vim.fn['minpac#status'],
+	}
+
+	-- load minpac
+	minpac.init{ confirm = false }
+	minpac.add('k-takata/minpac', {type = 'opt'})
+
+	-- load/install core packages
+	load_file_lenient(fey_core_d .. '/packages.lua')
+
+	-- load/install packages
+	for category, modules in pairs(dofile(init_f)) do -- NOTE: duplicate #1 ]]
+		for key, value in pairs(modules) do
+		local module = type(key) == 'string' and key or value
+		------------------------------------------------------------------- ]]
+		-- load module packages from ~/.config/fey/modules if possible, 
 		-- otherwise ~/.config/nvim/modules
-		local module_d = user_modules_d .. '/' .. category .. '/' .. module
+		
+		local module_d = user_modules_d .. '/' .. category .. '/' .. module -- NOTE: duplicate #2 ]]
 		if vim.fn.isdirectory(module_d) == 0 then
 			module_d = core_module_d .. '/' .. category .. '/' .. module
 		end
-		fey.load_module(module_d, category .. '_' .. module, features)
+		------------------------------------------------------------------- ]]
+		-- ACTION:
+		load_file_lenient(module_d .. '/packages.lua')
+		end
 	end
+end
+
+local load_modules = function()
+	-- loads ~/.config/nvim, or wherever FEY is installed. 
+	fey.load_module(fey_core_d, 'core')
+
+	-- loads ~/.config/fey, or similar. Runs the user's /config.lua
+	fey.load_module(fey_user_d, 'user')
+
+	for category, modules in pairs(dofile(init_f)) do -- NOTE: duplicate #1
+		-- that contain modules
+		for key, value in pairs(modules) do
+			-- sometimes the module's name is a string in list, sometimes
+			-- an index value
+			local module = type(key) == 'string' and key or value
+			-------------------------------------------------------------------]]
+			-- sometimes the modules have sub-features, if the key is a
+			-- number, set the value as the key (for convenience)
+			local features = type(value) == 'table' and value or {}
+			for key, value in pairs(features) do
+				if type(key) == 'number' then
+					features[value] = key
+				end
+			end
+
+			-- load up the module from ~/.config/fey/modules if possible, 
+			-- otherwise ~/.config/nvim/modules
+
+			local module_d = user_modules_d .. '/' .. category .. '/' .. module -- NOTE: duplicate #2 ]]
+			if vim.fn.isdirectory(module_d) == 0 then
+				module_d = core_module_d .. '/' .. category .. '/' .. module
+			end
+			-------------------------------------------------------------------- ]]
+			-- ACTION:
+			fey.load_module(module_d, category .. '_' .. module, features)
+		end
+	end
+end
+
+if fey_load_packages then
+	load_packages()
+elseif fey_load_config then
+	load_modules()
 end

--- a/init.lua
+++ b/init.lua
@@ -32,6 +32,14 @@ local function load_file_lenient(file)
 	end
 	return result
 end
+local function add_to_autload(module_d, name, config_f) 
+	local augroup = 'fey_' .. name
+	local autocmd_format = "autocmd! BufWritePost %s lua fey.load_module('%s', '%s')"
+	vim.cmd('augroup ' .. augroup)
+	vim.cmd('autocmd! ' .. augroup)
+	vim.cmd(string.format(autocmd_format, vim.fn.resolve(config_f), module_d, name))
+	vim.cmd('augroup END')
+end
 
 -- fey will contain 'public' global values and functions
 if fey == nil then fey = {} end
@@ -42,19 +50,11 @@ fey.load_module = function(module_d, name, features)
 	-- populate fey[name] with features
 	if fey[name] == nil then fey[name] = {} end
 	fey[name].features = features
-
-		-- load config.lua, with an augroup setup for the file's own
-		-- use and for us to put an autoreload autocmd
-		local config_f = module_d .. '/config.lua'
-
-		local augroup = 'fey_' .. name
-		vim.cmd('augroup ' .. augroup)
-		vim.cmd('autocmd! ' .. augroup)
-		vim.cmd('autocmd! BufWritePost ' .. vim.fn.resolve(config_f) .. " lua fey.load_module('" .. module_d .. "', '" .. name .. "')")
-
-		load_file_lenient(config_f)
-
-		vim.cmd('augroup END')
+	-- load config.lua, with an augroup setup for the file's own
+	-- use and for us to put an autoreload autocmd
+	local config_f = module_d .. '/config.lua'
+	add_to_autload(module_d, name, config_f)
+	load_file_lenient(config_f)
 end
 
 -- root path of init.lua to config/fey or ./skel


### PR DESCRIPTION
This very messy, and it needs further work before merging. One issue resulted
from the separation is duplication of code, we see the two loops and two
times the module_d gets defined. I'm sure you would fine many more

As of this commit, everything works fine, I've tested multiple time.

One advantage to this might be the ability to call load_packages from an
active session and have the plugin updated or install with the addition
of minpac.update to it.